### PR TITLE
Fixing outlook 2010 and 2013 display issues (2-column template)

### DIFF
--- a/email-templates/css/scss/bem/_two-column.scss
+++ b/email-templates/css/scss/bem/_two-column.scss
@@ -1,7 +1,7 @@
 body {
   -webkit-font-smoothing: antialiased;
   background-color: #f1f1f1;
-  font-family: Arial, sans-serif;
+  font-family: Helvetica, Arial, sans-serif;
   margin: 0;
   padding: 0;
   width: 100%;
@@ -43,12 +43,6 @@ table, table tr, table td {
     color: #fff;
   }
 
-  .header__wrap-inner {
-    img {
-      margin: 0 auto 30px;
-    }
-  }
-
   .header__title {
     border-bottom-width: 2px;
     border-bottom-style: solid;
@@ -58,7 +52,8 @@ table, table tr, table td {
   .header__title-text {
     font-size: 28px;
     font-weight: bold;
-    margin: 0 auto 30px;
+    // padding: 0 auto 30px;
+    font-family: Helvetica, Arial, sans-serif; // Outlook explicitly needs to be told what font to use here.
   }
 }
 
@@ -124,4 +119,6 @@ table, table tr, table td {
 
 .footer {
   width: 100%;
+  font-family: Helvetica, Arial, sans-serif; // Outlook explicitly needs to be told what font to use here.
+
 }

--- a/email-templates/emails/two-column.handlebars
+++ b/email-templates/emails/two-column.handlebars
@@ -12,12 +12,12 @@
       <table class="header">
         <tr class="header__preheader">
           <td>
-            <p>{{title}}</p>    
+            <p>{{title}}</p>
           </td>
         </tr>
         <tr class="header__wrap">
           <td>
-            <table class="header__wrap-inner">
+            <table class="header__wrap-inner" cellpadding="10">
               <tr>
                 <td align="center">
                   <a href="http://sustainability.asu.edu/" target="_blank" title="ASU's Global Institute of Sustainability">
@@ -30,7 +30,7 @@
         </tr>
         <tr class="header__title">
           <td>
-            <table class="header__title-inner">
+            <table class="header__title-inner" cellpadding="10">
               <tr>
                 <td align="center">
                   <p class="header__title-text">
@@ -53,7 +53,7 @@
     <td>
       <table class="content" align="center">
         <tr>
-          <td>  
+          <td>
             <table>
               <tr>
                 <td valign="top">


### PR DESCRIPTION
fixing the spacing between the logo and the title text,
also the font in the title and footer was falling back to sans-serif